### PR TITLE
Allow setting config and accessory data storage paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.42.1
+          args: -E gci -E gofmt -E whitespace -E misspell -E gosec -E goconst
           skip-go-installation: true
   build:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LINTERS := -E gci -E gofmt -E whitespace
+LINTERS := -E gci -E gofmt -E whitespace -E misspell -E gosec -E goconst
 
 all: vendor lint build
 

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	OAuthToken        string // path to the oauth token
 	HubName           string // name of the hub
 	PairingCode       string // 8 digits of pairing code
+	StoragePath       string // nesthub will store data at this path
 }
 
 func parse(path string) (Config, error) {

--- a/config.go
+++ b/config.go
@@ -30,8 +30,7 @@ func parse(path string) (Config, error) {
 	if err != nil {
 		return c, err
 	}
-	err = json.Unmarshal(b, &c)
-	if err != nil {
+	if err := json.Unmarshal(b, &c); err != nil {
 		return c, err
 	}
 	return c, nil
@@ -62,8 +61,7 @@ func (c Config) oauthToken() (oauth2.Token, error) {
 	if err != nil {
 		return t, err
 	}
-	err = json.Unmarshal(b, &t)
-	if err != nil {
+	if err := json.Unmarshal(b, &t); err != nil {
 		return t, err
 	}
 	return t, nil

--- a/config_example.json
+++ b/config_example.json
@@ -6,5 +6,6 @@
     "ServiceAccountKey": "path to credential of the GCP service account",
     "OAuthToken": "path to store oauth token",
     "HubName": "Name of the hub",
-    "PairingCode": "8 digits of pairing code"
+    "PairingCode": "8 digits of pairing code",
+    "StoragePath": "path where nesthub will store data"
 }

--- a/emulation.go
+++ b/emulation.go
@@ -13,6 +13,13 @@ import (
 	sdm "google.golang.org/api/smartdevicemanagement/v1"
 )
 
+const (
+	OFF      = "OFF"
+	HEAT     = "HEAT"
+	COOL     = "COOL"
+	HEATCOOL = "HEATCOOL"
+)
+
 type PubsubUpdate struct {
 	Timestamp      time.Time
 	ResourceUpdate struct {
@@ -169,13 +176,13 @@ func (d *EmulatedDevice) CurrentTemp() float64 {
 func (d *EmulatedDevice) TargetTemp() float64 {
 	mode := d.state.SetMode.Mode
 	switch mode {
-	case "OFF":
+	case OFF:
 		return 0
-	case "HEAT":
+	case HEAT:
 		return d.state.SetTemp.HeatCelsius
-	case "COOL":
+	case COOL:
 		return d.state.SetTemp.CoolCelsius
-	case "HEATCOOL":
+	case HEATCOOL:
 		return (d.state.SetTemp.HeatCelsius + d.state.SetTemp.CoolCelsius) / 2.0
 	default:
 		panic("unreachable set mode when querying target temp")
@@ -185,7 +192,7 @@ func (d *EmulatedDevice) TargetTemp() float64 {
 func (d *EmulatedDevice) CurrentHVACMode() int {
 	mode := d.state.CurrMode.Status
 	switch mode {
-	case "OFF":
+	case OFF:
 		return 0
 	case "HEATING":
 		return 1
@@ -199,13 +206,13 @@ func (d *EmulatedDevice) CurrentHVACMode() int {
 func (d *EmulatedDevice) TargetMode() int {
 	mode := d.state.SetMode.Mode
 	switch mode {
-	case "OFF":
+	case OFF:
 		return 0
-	case "HEAT":
+	case HEAT:
 		return 1
-	case "COOL":
+	case COOL:
 		return 2
-	case "HEATCOOL":
+	case HEATCOOL:
 		return 3
 	default:
 		panic("unreachable set mode")
@@ -216,13 +223,13 @@ func (d *EmulatedDevice) SetTargetMode(n int) error {
 	var s string
 	switch n {
 	case 0:
-		s = "OFF"
+		s = OFF
 	case 1:
-		s = "HEAT"
+		s = HEAT
 	case 2:
-		s = "COOL"
+		s = COOL
 	case 3:
-		s = "HEATCOOL"
+		s = HEATCOOL
 	default:
 		panic("unreachable target mode enumeration")
 	}
@@ -241,13 +248,13 @@ func (d *EmulatedDevice) SetTargetMode(n int) error {
 func (d *EmulatedDevice) SetTargetTemp(t float64) error {
 	var err error
 	switch d.state.SetMode.Mode {
-	case "OFF":
+	case OFF:
 		err = nil
-	case "HEAT":
+	case HEAT:
 		err = d.SetHeat(t)
-	case "COOL":
+	case COOL:
 		err = d.SetCool(t)
-	case "HEATCOOL":
+	case HEATCOOL:
 		err = d.SetHeatCool(t-2.5, t+2.5)
 	default:
 		panic("unreachable target mode when setting target temp")
@@ -259,13 +266,13 @@ func (d *EmulatedDevice) SetTargetTemp(t float64) error {
 	defer d.Unlock()
 	log.Println("Setting target temp to", t)
 	switch d.state.SetMode.Mode {
-	case "HEAT":
+	case HEAT:
 		d.state.SetTemp.HeatCelsius = t
 		d.state.SetTemp.HeatTimestamp = time.Now()
-	case "COOL":
+	case COOL:
 		d.state.SetTemp.CoolCelsius = t
 		d.state.SetTemp.CoolTimestamp = time.Now()
-	case "HEATCOOL":
+	case HEATCOOL:
 		d.state.SetTemp.HeatCelsius = t - 2.5
 		d.state.SetTemp.CoolCelsius = t + 2.5
 		d.state.SetTemp.HeatTimestamp = time.Now()

--- a/emulation.go
+++ b/emulation.go
@@ -92,8 +92,7 @@ func NewEmulatedDevice(t *service.Thermostat, c Config) (*EmulatedDevice, error)
 	}()
 
 	// query the API once to get the initial traits
-	err = e.ForceUpdate()
-	if err != nil {
+	if err := e.ForceUpdate(); err != nil {
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -19,15 +19,13 @@ func main() {
 	}
 
 	if *doSetupFlag {
-		err = setup(c)
-		if err != nil {
+		if err := setup(c); err != nil {
 			log.Fatalln(err)
 		}
 	}
 
 	svc := service.NewThermostat()
-	_, err = NewEmulatedDevice(svc, c)
-	if err != nil {
+	if _, err := NewEmulatedDevice(svc, c); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Device emulation started")

--- a/main.go
+++ b/main.go
@@ -11,9 +11,15 @@ import (
 
 func main() {
 	doSetupFlag := flag.Bool("setup", false, "go through the setup routine")
+	configPathFlag := flag.String("config", "config.json", "path to the config file")
 	flag.Parse()
 
-	c, err := parse("config.json")
+	configPath := "config.json"
+	if configPathFlag != nil {
+		configPath = *configPathFlag
+	}
+
+	c, err := parse(configPath)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -40,8 +46,9 @@ func main() {
 
 	// add the service to the bridge
 	acc.AddService(svc.Service)
+	log.Println(c.StoragePath)
 
-	t, err := hc.NewIPTransport(hc.Config{Pin: c.PairingCode}, acc.Accessory)
+	t, err := hc.NewIPTransport(hc.Config{Pin: c.PairingCode, StoragePath: c.StoragePath}, acc.Accessory)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/onboard.go
+++ b/onboard.go
@@ -89,8 +89,8 @@ func setup(config Config) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(config.OAuthToken, tokenJson, 0644)
-	if err != nil {
+
+	if err := ioutil.WriteFile(config.OAuthToken, tokenJson, 0600); err != nil {
 		return err
 	}
 

--- a/onboard.go
+++ b/onboard.go
@@ -42,8 +42,7 @@ func setup(config Config) error {
 			}
 		} else {
 			time.Sleep(1 * time.Second)
-			op, err = s.Operations.Get(opName).Do()
-			if err != nil {
+			if _, err := s.Operations.Get(opName).Do(); err != nil {
 				return err
 			}
 		}

--- a/sdm.go
+++ b/sdm.go
@@ -44,8 +44,7 @@ func (d *DeviceEndpoint) GetDevice() (DeviceTraits, error) {
 		return r, err
 	}
 
-	err = json.Unmarshal(res.Traits, &r)
-	if err != nil {
+	if err := json.Unmarshal(res.Traits, &r); err != nil {
 		return r, err
 	}
 
@@ -67,8 +66,7 @@ func (d *DeviceEndpoint) SetMode(mode string) error {
 		Command: "sdm.devices.commands.ThermostatMode.SetMode",
 		Params:  ep,
 	}
-	_, err = d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do()
-	if err != nil {
+	if _, err := d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do(); err != nil {
 		return err
 	}
 	return nil
@@ -89,8 +87,7 @@ func (d *DeviceEndpoint) SetHeat(temp float64) error {
 		Command: "sdm.devices.commands.ThermostatTemperatureSetpoint.SetHeat",
 		Params:  ep,
 	}
-	_, err = d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do()
-	if err != nil {
+	if _, err := d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do(); err != nil {
 		return err
 	}
 	return nil
@@ -111,8 +108,7 @@ func (d *DeviceEndpoint) SetCool(temp float64) error {
 		Command: "sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool",
 		Params:  ep,
 	}
-	_, err = d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do()
-	if err != nil {
+	if _, err := d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do(); err != nil {
 		return err
 	}
 	return nil
@@ -135,8 +131,7 @@ func (d *DeviceEndpoint) SetHeatCool(heat, cool float64) error {
 		Command: "sdm.devices.commands.ThermostatTemperatureSetpoint.SetRange",
 		Params:  ep,
 	}
-	_, err = d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do()
-	if err != nil {
+	if _, err := d.Enterprises.Devices.ExecuteCommand(d.Name, req).Do(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This PR allows users to choose the config location and accessory data storage paths. This is necessary to run Nesthub in NixOS where many locations are not writable. These changes are backwards compatible with previous configs and will default to previous locations.

This PR also, adds `misspell`, `gosec`, `goconst` linters.