### PR TITLE
Configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Cons:
     + Does not hit the ridiculously low API rate limit.
 + Device state query (e.g. check temperature) is entirely local. (Low latency.)
 
+## Networking and Firewall Rules
+If you're configuring a firewall, you can set the TCP port used by Nesthub in the config. By default the application will choose an open port on start. You'll also need to leave UDP 5353 open for mDNS queries.
+
 ## Acknowledgements
 
 This project uses hc for a pure-go implementation of the HomeKit Accessory

--- a/config.go
+++ b/config.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Config struct {
-	SDMProjectID      string // the project ID shown in the SDM console
-	OAuthClientID     string // the oauth client ID created in GCP and set in SDM project
-	OAuthClientSecret string // the oauth client secret created in GCP
-	GCPProjectID      string // the project ID shown in the GCP console
-	ServiceAccountKey string // credentials of the service account of GCP project
-	OAuthToken        string // path to the oauth token
-	HubName           string // name of the hub
-	PairingCode       string // 8 digits of pairing code
-	StoragePath       string // nesthub will store data at this path
+	SDMProjectID      string // the project ID shown in the SDM console, required
+	OAuthClientID     string // the oauth client ID created in GCP and set in SDM project, required
+	OAuthClientSecret string // the oauth client secret created in GCP, required
+	GCPProjectID      string // the project ID shown in the GCP console, required
+	ServiceAccountKey string // credentials of the service account of GCP project, required
+	OAuthToken        string // path to the oauth token, required
+	HubName           string // name of the hub, required
+	PairingCode       string // 8 digits of pairing code, optional
+	Port              string // TCP port to listen on, optional
+	StoragePath       string // nesthub will store data at this path, optional
 }
 
 func parse(path string) (Config, error) {

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 	acc.AddService(svc.Service)
 	log.Println(c.StoragePath)
 
-	t, err := hc.NewIPTransport(hc.Config{Pin: c.PairingCode, StoragePath: c.StoragePath}, acc.Accessory)
+	t, err := hc.NewIPTransport(hc.Config{Pin: c.PairingCode, StoragePath: c.StoragePath, Port: c.Port}, acc.Accessory)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
This PR allows the port to be configured. Being able to set a static port makes it easier for firewall administrators to allow Nesthub to run on their network. Also added a networking section in the README